### PR TITLE
#7 Display urgent messages to candidates

### DIFF
--- a/platform/functions/actions/qualifyingTests/onUpdate.js
+++ b/platform/functions/actions/qualifyingTests/onUpdate.js
@@ -1,0 +1,48 @@
+const { applyUpdates, getDocuments } = require('../../shared/helpers');
+
+module.exports = (config, firebase, db) => {
+  return onUpdate;
+
+  /**
+   * Qualifying Test event handler for Update
+   * - if message has changed then update all Qualifying Test Responses
+   */
+  async function onUpdate(qualifyingTestId, dataBefore, dataAfter) {
+    const commands = [];
+
+    const msgInDataBefore = 'message' in dataBefore;
+    const msgInDataAfter = 'message' in dataAfter;
+
+    const msgRemoved = msgInDataBefore && !msgInDataAfter || dataAfter.message === '';
+    const msgAdded = !msgInDataBefore && msgInDataAfter;
+    const msgUpdated = msgInDataBefore && msgInDataAfter && (dataBefore.message !== dataAfter.message);
+
+    const msgChanged = msgRemoved || msgAdded || msgUpdated;
+
+    if (msgChanged) {
+
+      // Get QTR records for this QT
+      const qualifyingTestResponsesRef = db.collection('qualifyingTestResponses')
+        .where('qualifyingTest.id', '==', qualifyingTestId)
+        .select('id');
+      const qualifyingTestResponseRecords = await getDocuments(qualifyingTestResponsesRef);
+      const qualifyingTestResponseRecordIds = qualifyingTestResponseRecords.map(item => item.id);
+      for (let i = 0, len = qualifyingTestResponseRecordIds.length; i < len; ++i) {
+        const qualifyingTestResponseRecordId = qualifyingTestResponseRecordIds[i];
+        commands.push({
+          command: 'update',
+          ref: db.collection('qualifyingTestResponses').doc(qualifyingTestResponseRecordId),
+          data: {
+            message: dataAfter.message,
+          },
+        });
+      }
+    }
+
+    if (commands.length) {
+      const result = await applyUpdates(db, commands);
+      return result ? true : false;
+    }
+    return true;
+  }
+};

--- a/platform/functions/actions/qualifyingTests/onUpdate.js
+++ b/platform/functions/actions/qualifyingTests/onUpdate.js
@@ -13,7 +13,7 @@ module.exports = (config, firebase, db) => {
     const msgInDataBefore = 'message' in dataBefore;
     const msgInDataAfter = 'message' in dataAfter;
 
-    const msgRemoved = msgInDataBefore && !msgInDataAfter || dataAfter.message === '';
+    const msgRemoved = msgInDataBefore && !msgInDataAfter || (dataBefore.message !== '' && dataAfter.message === '');
     const msgAdded = !msgInDataBefore && msgInDataAfter;
     const msgUpdated = msgInDataBefore && msgInDataAfter && (dataBefore.message !== dataAfter.message);
 

--- a/platform/functions/backgroundFunctions/onQualifyingTestUpdate.js
+++ b/platform/functions/backgroundFunctions/onQualifyingTestUpdate.js
@@ -1,0 +1,12 @@
+const functions = require('firebase-functions');
+const config = require('../shared/config');
+const { firebase, db } = require('../shared/admin.js');
+const onQualifyingTestUpdate = require('../actions/qualifyingTests/onUpdate')(config, firebase, db);
+
+module.exports = functions.region('europe-west2').firestore
+  .document('qualifyingTests/{qualifyingTestId}')
+  .onUpdate((change, context) => {
+    const dataBefore = change.before.data();
+    const dataAfter = change.after.data();
+    return onQualifyingTestUpdate(context.params.qualifyingTestId, dataBefore, dataAfter);
+  });

--- a/platform/functions/index.js
+++ b/platform/functions/index.js
@@ -7,6 +7,7 @@ exports.backupAuthentication = require('./scheduledFunctions/backupAuthenticatio
 // Background
 exports.onDelete = require('./backgroundFunctions/onDelete');
 exports.onQualifyingTestResponseUpdate = require('./backgroundFunctions/onQualifyingTestResponseUpdate');
+exports.onQualifyingTestUpdate = require('./backgroundFunctions/onQualifyingTestUpdate');
 
 // Callable
 exports.api = require('./callableFunctions/api');

--- a/qt-admin/src/components/Micro/EditableMessage.vue
+++ b/qt-admin/src/components/Micro/EditableMessage.vue
@@ -1,0 +1,57 @@
+<template>
+  <EditableField
+    type="textarea"
+    :value="message"
+    field="message"
+    :edit-mode="true"
+    @changeField="setMessage"
+  />
+</template>
+<script>
+import EditableField from '@jac-uk/jac-kit/draftComponents/EditableField';
+export default {
+  name: 'EditableMessage',
+  components: {
+    EditableField,
+  },
+  props: {
+    getter: {
+      type: String,
+      required: true,
+    },
+    dispatcher: {
+      type: String,
+      required: true,
+    },
+    recordId: {
+      type: String,
+    },
+    message: {
+      type: String,
+    },
+  },
+  methods: {
+    async setMessage(obj) {
+      let storeObj;
+      const data = this.$store.getters[this.getter]();
+      if ('message' in data) {
+        storeObj = { ...data };
+        storeObj.message = obj.message;
+      }
+      else {
+        storeObj = { ...obj, ...data };
+      }
+      // @TODO: this is a temp fix until we have a store module dedicated to a single QTR
+      if (this.recordId) {
+        await this.$store.dispatch(this.dispatcher, {
+          id: this.recordId,
+          data: storeObj,
+        });
+      }
+      else {
+        await this.$store.dispatch(this.dispatcher, storeObj);
+      }
+    },
+  },
+};
+</script>

--- a/qt-admin/src/store/qualifyingTest/qualifyingTestResponses.js
+++ b/qt-admin/src/store/qualifyingTest/qualifyingTestResponses.js
@@ -5,6 +5,7 @@ import vuexfireSerialize from '@jac-uk/jac-kit/helpers/vuexfireSerialize';
 import tableQuery from '@jac-uk/jac-kit/components/Table/tableQuery';
 import { QUALIFYING_TEST, QUALIFYING_TEST_RESPONSE } from '@/helpers/constants';
 import { authorisedToPerformAction } from '@/helpers/authUsers';
+import clone from 'clone';
 
 const collectionRef = firestore.collection('qualifyingTestResponses');
 
@@ -152,5 +153,14 @@ export default {
   state: {
     records: [],
     record: null,
+  },
+  getters: {
+    id: (state) => {
+      if (state.record === null) return null;
+      return state.record.id;
+    },
+    data: (state) => () => {
+      return clone(state.record);
+    },
   },
 };

--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/Response/View.vue
@@ -184,6 +184,19 @@
             </table>
           </dd>
         </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Message
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <EditableMessage
+              getter="qualifyingTestResponses/data"
+              dispatcher="qualifyingTestResponses/update"
+              :message="responseMessage"
+              :record-id="responseId"
+            />
+          </dd>
+        </div>
       </dl>
       <Modal ref="confirmResetModal">
         <div class="container">
@@ -486,6 +499,7 @@ import QuestionDuration from '@/components/Micro/QuestionDuration';
 import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
 import { authorisedToPerformAction }  from '@/helpers/authUsers';
 import Modal from '@jac-uk/jac-kit/components/Modal/Modal';
+import EditableMessage from '@/components/Micro/EditableMessage';
 
 export default {
   components: {
@@ -495,6 +509,7 @@ export default {
     Modal,
     QuestionDuration,
     ActionButton,
+    EditableMessage,
   },
   data() {
     return {
@@ -541,6 +556,9 @@ export default {
     response() {
       const qtList = this.$store.state.qualifyingTestResponses.record;
       return qtList;
+    },
+    responseMessage() {
+      return ('message' in this.response) ? this.response.message : '';
     },
     responses() {
       let responses = [];

--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/View.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/View.vue
@@ -57,6 +57,21 @@
               </a>
             </td>
           </tr>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">
+              Message
+            </th>
+            <td
+              class="govuk-table__cell"
+              colspan="3"
+            >
+              <EditableMessage
+                getter="qualifyingTest/data"
+                dispatcher="qualifyingTest/save"
+                :message="qualifyingTestMessage"
+              />
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -272,11 +287,12 @@ import ActionButton from '@jac-uk/jac-kit/draftComponents/ActionButton';
 import { QUALIFYING_TEST } from '@/helpers/constants';
 import { isDateGreaterThan } from '@jac-uk/jac-kit/helpers/date';
 import Banner from '@jac-uk/jac-kit/draftComponents/Banner';
-
+import EditableMessage from '@/components/Micro/EditableMessage';
 export default {
   components: {
     ActionButton,
     Banner,
+    EditableMessage,
   },
   data() {
     return {
@@ -308,6 +324,9 @@ export default {
     },
     qualifyingTest() {
       return this.$store.state.qualifyingTest.record;
+    },
+    qualifyingTestMessage() {
+      return ('message' in this.qualifyingTest) ? this.qualifyingTest.message : '';
     },
     testURL() {
       let url = '';

--- a/qt/src/views/QualifyingTests/QualifyingTest.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest.vue
@@ -45,6 +45,14 @@
           </a>
         </template>
       </Countdown>
+      <Banner
+        v-if="message"
+        status="information"
+      >
+        <template>
+          {{ message }}
+        </template>
+      </Banner>
       <Modal
         ref="timeElapsedModalRef"
         title="Time has expired"
@@ -76,12 +84,13 @@ import firebase from '@/firebase';
 import LoadingMessage from '@/components/LoadingMessage';
 import Modal from '@/components/Page/Modal';
 import Countdown from '@/components/QualifyingTest/Countdown';
-
+import Banner from '@/components/Page/Banner';
 export default {
   components: {
     LoadingMessage,
     Modal,
     Countdown,
+    Banner,
   },
   data() {
     return {
@@ -106,6 +115,12 @@ export default {
     },
     isSupportingPage() {
       return ['online-test-information', 'online-test-submitted'].indexOf(this.$route.name) >= 0;
+    },
+    message() {
+      if (this.qualifyingTestResponse && ('message' in this.qualifyingTestResponse)) {
+        return this.qualifyingTestResponse.message;
+      }
+      return '';
     },
   },
   watch: {

--- a/qt/src/views/QualifyingTests/QualifyingTest.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest.vue
@@ -46,7 +46,7 @@
         </template>
       </Countdown>
       <Banner
-        v-if="message"
+        v-if="message && !isCompleted"
         status="information"
       >
         <template>
@@ -121,6 +121,9 @@ export default {
         return this.qualifyingTestResponse.message;
       }
       return '';
+    },
+    isCompleted() {
+      return this.$store.getters['qualifyingTestResponse/isCompleted'];
     },
   },
   watch: {

--- a/qt/src/views/QualifyingTests/QualifyingTests.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTests.vue
@@ -25,6 +25,8 @@
               <br>
               <span v-if="isFutureTest(row)">Start {{ prettyDate(row.qualifyingTest.startDate) }}<br></span>
               <span v-else>Deadline {{ prettyDate(row.qualifyingTest.endDate) }}</span>
+              <br />
+              <span v-if="qualifyingTestMessage(row)">Message: {{ qualifyingTestMessage(row) }}</span>
             </TableCell>
             <TableCell>
               {{ status(row) | lookup }}<br>
@@ -74,9 +76,6 @@ export default {
     };
   },
   computed: {
-    showFeedbackColumn() {
-      return this.closedTests.some((element) => element.qualifyingTest.feedbackSurvey);
-    },
     qualifyingTestResponses() {
       return this.$store.state.qualifyingTestResponses.records.concat(this.$store.state.qualifyingTestResponses.dryRuns)
         .filter((qt, index, qts) => qts.findIndex(i => i.id === qt.id) === index);
@@ -158,6 +157,12 @@ export default {
     isFutureTest(qt) {
       return isDateInFuture(qt.qualifyingTest.startDate)
         || (isDateInFuture(qt.qualifyingTest.endDate) && qt.status === QUALIFYING_TEST.STATUS.CREATED);
+    },
+    qualifyingTestMessage(qtr) {
+      if ('message' in qtr) {
+        return qtr.message;
+      }
+      return '';
     },
   },
 };


### PR DESCRIPTION
## What's included?

Allow admins to set messages for candidates to see when taking tests.
Specifically:

Display a message to anyone taking test 'ABC123'
Only those on the Qualifying Tests and Information pages for test ID 'ABC123' will see this

Display a message to specific candidate taking test 'MyTest5678'
Only the candidate taking qualifying test response ID 'MyTest5678' will see this

Closes #7 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Setup
The tester should login as an Admin and set up two QTs and invite two candidates (User A and User B for simplicity) to take these tests.

Test 1
The Admin should go to the page for the first QT and click the Responses button.
They should then click the View link against User A and set the message (see screenshot below).

<img width="1275" alt="Test2a" src="https://github.com/jac-uk/qt/assets/115651787/b0f96ff2-1b8a-408f-b2fa-f70257be71bb">

The tester should then access this test as a candidate and see the message as per the screenshot below:

<img width="1243" alt="Test2b" src="https://github.com/jac-uk/qt/assets/115651787/e6cc6439-eadc-4234-8a6b-5cfd1b05b822">

The tester should then click into the test with the message and ensure they can see the message on the banner in the subsequent Information page, as per the screenshot below:

<img width="1249" alt="Test2c" src="https://github.com/jac-uk/qt/assets/115651787/87655435-6465-4672-a5bf-34739a84d155">

The tester should then check the checkbox and click the Start Now button to start the test and ensure they can see the message on the banner in the subsequent test page, as per the screenshot below:

<img width="1249" alt="Test2d" src="https://github.com/jac-uk/qt/assets/115651787/dc2649e7-be28-48e2-8f4d-0c810e6ba5e7">

Note that the message should not appear on the submitted page once the test has been completed. See screenshot below:

<img width="1237" alt="Test2e" src="https://github.com/jac-uk/qt/assets/115651787/0b2beda7-322d-4e39-8591-d530f575d0bd">

The tester should ensure that if they click into the other test the msg does not appear on the Information nor Test pages.
The tester should then login as another candidate and ensure that no msgs are displayed on the Information nor Test pages.

Test 2
The Admin should go to the page for the first QT and set the message (see screenshot below).

<img width="1728" alt="Test 1" src="https://github.com/jac-uk/qt/assets/115651787/2c648233-bfd6-4b3e-83c3-85d8a96b2a87">

The tester should then access this test as a candidate and see the message as per the screenshot below:

<img width="1250" alt="Test1a" src="https://github.com/jac-uk/qt/assets/115651787/8fde6038-89e6-44a3-b227-aa61f9ccfc19">

The tester should then click into the test with the message and ensure they can see the message on the banner in the subsequent Information page, as per the screenshot below:

<img width="1244" alt="Test1b" src="https://github.com/jac-uk/qt/assets/115651787/0b1f1c00-c706-4fee-8426-e374e184d016">

The tester should then check the checkbox and click the Start Now button to start the test and ensure they can see the message on the banner in the subsequent test page, as per the screenshot below:

<img width="1320" alt="Test1c" src="https://github.com/jac-uk/qt/assets/115651787/83a137e9-d699-4902-a209-426802284119">

The tester should then login as another candidate and ensure all of the steps above are the same (ie that they can see the msgs in the same pages)!
The tester should then click into the other test and ensure that no msgs are displayed on the Information nor Test pages.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_

