### PR TITLE
#22 Exit out QTs

### DIFF
--- a/qt/src/views/QualifyingTests/QualifyingTest.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest.vue
@@ -147,6 +147,12 @@ export default {
   async created() {
     await this.loadQualifyingTestResponse();
   },
+  mounted() {
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
+  },
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
+  },
   destroyed() {
     this.$store.dispatch('qualifyingTestResponse/unbind');
   },
@@ -247,6 +253,13 @@ export default {
         }),
       };
       return objToSave;
+    },
+    handleBeforeUnload(event) {
+      if (!this.exitTest) {
+        // Show default browser msg warning user they're closing the tab/window
+        event.preventDefault();
+        event.returnValue = '';
+      }
     },
   },
 };

--- a/qt/src/views/QualifyingTests/QualifyingTest/Submitted.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Submitted.vue
@@ -4,7 +4,7 @@
       <h1 class="govuk-panel__title">
         Test Submitted
       </h1>
-      Your test has been submitted and is now complete.<br />You will receive an email confirmation of your test submission shortly.
+      Your test has been submitted and is now complete.<br>You will receive an email confirmation of your test submission shortly.
     </div>
 
     <div class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-6">


### PR DESCRIPTION
Closes #22

Show default browser message if candidate tries to close the tab/browser whilst still in a test unless they have confirmed they wish to exit the test prematurely.

Also fixed a small lint error.

## How to test

Visit the following URL:
https://jac-qualifying-tests-develop--22-exit-out-qts-0ijgmlld.web.app/fhr2RUAfBXHullz4fcYq

Log in with one of the following demo users for the 'QT 22 Exit out QTs' test:
test1@sharklasers.com
test2@sharklasers.com
test3@sharklasers.com
test4@sharklasers.com
test5@sharklasers.com
test6@sharklasers.com
test7@sharklasers.com
test8@sharklasers.com
test9@sharklasers.com
test10@sharklasers.com
test11@sharklasers.com
test12@sharklasers.com

Start the test and then try each of the following actions:

 - Close the browser tab
 - Close the browser

In both cases you should see a message checking that you mean to close the page.
Previously in both cases the page would have closed without warning.

Example message displayed in Google Chrome:
<img width="708" alt="image" src="https://github.com/jac-uk/qt/assets/8524401/6047acc7-4a4a-4c50-8754-795a71b6b91c">

Example message displayed in Firefox:
<img width="631" alt="image" src="https://github.com/jac-uk/qt/assets/8524401/1d543c3e-f2f3-46b1-bf2d-423d320a56fc">

Example message displayed in Safari:
<img width="649" alt="image" src="https://github.com/jac-uk/qt/assets/8524401/dd79eee9-4db6-4b91-8fa8-59a5236d83b9">

Example message displayed in Edge:
<img width="580" alt="image" src="https://github.com/jac-uk/qt/assets/8524401/4730d2ca-bca6-412f-8926-d61aa8226a5c">