### PR TITLE
#18 Candidate Able To Exceed Word Limit In Answer To Scenario Test

### DIFF
--- a/qt/src/components/Form/TextareaInput.vue
+++ b/qt/src/components/Form/TextareaInput.vue
@@ -27,9 +27,7 @@
       class="govuk-textarea"
       name="word-count"
       :rows="rows"
-      @keydown="handleLimit($event)"
       @keyup="handleLimit($event)"
-      @change="validate"
     />
     <div
       v-if="wordLimit"
@@ -111,8 +109,8 @@ export default {
   },
 
   methods: {
-    handleLimit(e){
-      if (this.wordLimit && [8, 46].indexOf(e.keyCode) === -1) {
+    handleLimit(){
+      if (this.wordLimit) {
         this.handleValidate();
         if (this.hardWordLimit) {
           this.enforceHardWordLimit();

--- a/qt/src/components/Form/TextareaInput.vue
+++ b/qt/src/components/Form/TextareaInput.vue
@@ -71,8 +71,16 @@ export default {
       default: false,
       type: Boolean,
     },
+    hardWordLimit: {
+      default: false,
+      type: Boolean,
+    },
   },
-
+  data() {
+    return {
+      previousValidText: '',
+    };
+  },
   computed: {
     wordsTooMany() {
       return this.words.length - this.wordLimit;
@@ -85,11 +93,11 @@ export default {
       } else if (Math.floor(this.wordLimit * 0.20) > Math.abs(this.wordsTooMany)) {
         result = `You have ${Math.abs(this.wordsTooMany)} word${plural} remaining`;
       } else {
-        result = `${this.words.length}/${this.wordLimit}`;
+        result = `${this.words.length}/${this.wordLimit} words`;
       }
       if (this.wordsTooMany == 0) {
         result = 'You have no words remaining';
-      } 
+      }
       return result;
     },
     text: {
@@ -106,6 +114,17 @@ export default {
     handleLimit(e){
       if (this.wordLimit && [8, 46].indexOf(e.keyCode) === -1) {
         this.handleValidate();
+        if (this.hardWordLimit) {
+          this.enforceHardWordLimit();
+        }
+      }
+    },
+    enforceHardWordLimit() {
+      if (this.words.length > this.wordLimit) {
+        this.text = this.previousValidText;
+      }
+      else {
+        this.previousValidText = this.text;
       }
     },
   },

--- a/qt/src/views/QualifyingTests/QualifyingTest/Scenario.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Scenario.vue
@@ -27,18 +27,11 @@
               v-model="response.text"
               :label="`${questionNumber}. ${question.question}`"
               :hint="$options.filters.showHTMLBreaks(question.hint) || 'Answer below:'"
+              :word-limit="wordLimit"
+              :hard-word-limit="true"
               rows="10"
               required
             />
-            <div class="govuk-body">
-              <span>{{ wordsCounter }}</span>
-              <span>/</span>
-              <span>{{ question.wordLimit }}</span>
-              <span> words</span>
-              <div v-if="reachMaxWords">
-                You have reached the limit of <strong>{{ question.wordLimit }}</strong> words for this answer. Please remove some words.
-              </div>
-            </div>
           </div>
 
           <div class="moj-button-menu">
@@ -208,12 +201,15 @@ export default {
       return words;
     },
     reachMaxWords () {
-      const maxWords = this.question.wordLimit;
+      const maxWords = this.wordLimit;
       const reachedMaxWords = this.wordsCounter > maxWords;
       return reachedMaxWords;
     },
     isEmpty () {
       return (this.response && !this.response.text) || (this.response && this.response.text && this.response.text.trim().length === 0);
+    },
+    wordLimit() {
+      return this.question.wordLimit;
     },
   },
   watch: {


### PR DESCRIPTION
Added hard limit check in TeatAreaInput component to prevent users from adding any more characters after word limit is reached.

Closes #18 

Use the following link: https://qt-develop.judicialappointments.digital/28Ht4QmAunCBrdzuhqtD
And click on the 'ST For Testing Word Limit' test.
**Note that I have set a very short word limit to aid testing!**

Use the following emails to test with:

test2@test.com
test3@test.com
test4@test.com
test5@test.com
test6@test.com
test7@test.com
test8@test.com
test9@test.com
test10@test.com

Please perform the following tests:

**Test 1**

- Whilst typing try to exceed the word limit
- You should be prevent from adding more than the specified word limit
- You should see an error when you try to exceed the word limit
- If you use backspace so you're back within the word limit the error should disappear

**Test 2**

- Paste an amount of text into the input which exceeds the word limit
- The text you pasted should be cut off at the word limit
- You should see an error when you exceed the word limit
- If you use backspace so you're back within the word limit the error should disappear