### PR TITLE
Feature/41 Add link to QT feedback survey to the QT confirmation email

### DIFF
--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -40,14 +40,16 @@ module.exports = (config, firebase, db) => {
 
         // Send email to candidate confirming their test response has been received
         const participantEmail = dataAfter.participant.email;
-        const templateId  = '3717496b-69d7-4eab-b6bd-3b7815e4efc6';
+        const feedbackSurvey = dataAfter.qualifyingTest.feedbackSurvey;
+        // check if feedback survey link exists
+        const templateId  = feedbackSurvey ? 'ea226c24-de15-4c51-9d5b-28755c9824b1' : '3717496b-69d7-4eab-b6bd-3b7815e4efc6';
         const testType = ('type' in dataAfter && dataAfter.type) ? dataAfter.type
           .replace(/([a-z])([A-Z])/g, '$1 $2')  // insert a space between lower & upper & make lowercase
           .toLowercase() : '';
         const personalisation = {
           testTitle: dataAfter.qualifyingTest.title,
           testType: testType,
-          feedbackSurvey: dataAfter.qualifyingTest.feedbackSurvey,
+          feedbackSurvey: feedbackSurvey,
         };
         sendEmail(participantEmail, templateId, personalisation);
       }

--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -47,6 +47,7 @@ module.exports = (config, firebase, db) => {
         const personalisation = {
           testTitle: dataAfter.qualifyingTest.title,
           testType: testType,
+          feedbackSurvey: dataAfter.qualifyingTest.feedbackSurvey,
         };
         sendEmail(participantEmail, templateId, personalisation);
       }


### PR DESCRIPTION
## What's included?
Closes #41  

- [x] Add the link to the QT feedback survey to the QT confirmation email.
- [x] Create [QT Completed Test Candidate Confirmation (with feedback survey link)](https://www.notifications.service.gov.uk/services/0abe6c8e-0b87-4cde-9493-5da4921ccc53/templates/ea226c24-de15-4c51-9d5b-28755c9824b1) on Notify.
    <img width="736" alt="Screenshot 2023-12-29 at 15 01 33" src="https://github.com/jac-uk/qt/assets/79906532/99732640-3deb-4dc8-8146-71213047633f">


## Who should test?
✅ Product owner
✅ Developers

## How to test?

Example QT: https://qt-develop.judicialappointments.digital/lTikYARL14GGDz6Lh5EI

1. Sit and submit the QT with your JAC email address
2. Check if the feedback survey link appears in the QT confirmation email.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
