### PR TITLE
Feature/30 Ensure timer does not pause when test loses focus

### DIFF
--- a/qt/src/components/QualifyingTest/Countdown.vue
+++ b/qt/src/components/QualifyingTest/Countdown.vue
@@ -162,6 +162,8 @@ export default {
         } else if (e.data.action === 'ended') {
           this.$emit('change', { action: 'ended' });
           this.endCountdown();
+        } else if (e.data.action === 'refresh') {
+          this.$emit('change', { action: 'refresh' });
         } else if (e.data.action === 'update') {
           const timeRemaining = e.data.payload.timeRemaining;
           this.hours = Math.floor((timeRemaining % (24 * 60 * minute)) / (60 * minute));

--- a/qt/src/helpers/browser.js
+++ b/qt/src/helpers/browser.js
@@ -70,7 +70,24 @@ const getBrowserDetect = () => {
   return browserObj;
 };
 
+// Check if web worker is supported
+const isWebWorkerSupported = () => {
+  return typeof Worker !== 'undefined';
+};
+
+// Create a worker script from a function
+// ref: https://medium.com/@adithyaviswam/overcoming-browser-throttling-of-setinterval-executions-45387853a826
+const createWorkerScript = (workerCode) => {
+  let code = workerCode.toString();
+  code = code.substring(code.indexOf('{') + 1, code.lastIndexOf('}'));
+  const blob = new Blob([code], { type: 'application/javascript' });
+  const workerScript = URL.createObjectURL(blob);
+  return workerScript;
+};
+
 export {
   getIPAddress,
   getBrowserDetect,
+  isWebWorkerSupported,
+  createWorkerScript,
 };

--- a/qt/src/workers/countdown.js
+++ b/qt/src/workers/countdown.js
@@ -1,0 +1,70 @@
+import { createWorkerScript } from '@/helpers/browser';
+
+const workerCode = () => {
+  let countdown;          // setInterval reference
+  const second = 1000;
+  let saveCounter = 0;    // counter for autoSave
+  let saveSeconds = 5;    // autoSave every 5 seconds
+  let ticksPerSecond = 1;
+  let end;                // end time in milliseconds
+  let serverTimeOffset;   // server time offset in milliseconds
+
+  const getTimeRemaining = () => {
+    const currentLocalTime = new Date().getTime();
+    const now = currentLocalTime + serverTimeOffset;
+    const timeRemaining = end - now;
+    return timeRemaining;
+  };
+
+  const startCountdown = (payload) => {
+    // stop previous countdown if exists
+    if (countdown) {
+      clearInterval(countdown);
+    }
+
+    // set new countdown
+    saveSeconds = payload.saveSeconds;
+    ticksPerSecond = payload.ticksPerSecond;
+    end = payload.end;
+    serverTimeOffset = payload.serverTimeOffset;
+
+    const timeRemaining = getTimeRemaining();
+    postMessage({ action: 'update', payload: { timeRemaining } });
+
+    countdown = setInterval(() => {
+      saveCounter++;
+      if (saveCounter === saveSeconds * ticksPerSecond) {
+        postMessage({ action: 'autoSave' });
+        saveCounter = 0;
+      }
+      if (saveCounter === (2 * ticksPerSecond)) { // clean the autoSaver 2s after it is set to true
+        postMessage({ action: 'cleanAutoSave' });
+      }
+
+      const timeRemaining = getTimeRemaining();
+      postMessage({ action: 'update', payload: { timeRemaining } });
+
+      if (timeRemaining <= 0) {
+        postMessage({ action: 'ended' });
+        clearInterval(countdown);
+      }
+    }, second / ticksPerSecond);
+  };
+
+  const stopCountdown = () => {
+    clearInterval(countdown);
+  };
+
+  // listen to messages from the main thread
+  onmessage = function (e) {
+    if (e.data.action === 'start') {
+      startCountdown(e.data.payload);
+    } else if (e.data.action === 'stop') {
+      stopCountdown();
+    }
+  };
+};
+
+const workerScript = createWorkerScript(workerCode);
+
+export default workerScript;

--- a/qt/src/workers/countdown.js
+++ b/qt/src/workers/countdown.js
@@ -47,6 +47,7 @@ const workerCode = () => {
       const diff = Math.abs(previousTimeRemaining - timeRemaining);
       // check if time remaining has changed by more than 2 seconds to avoid local time changes
       if (diff > second * 2) {
+        // adjust current time remaining based on previous value
         timeRemaining = previousTimeRemaining - second;
         postMessage({ action: 'refresh' });
       }


### PR DESCRIPTION
## What's included?
Closes #30 

- Use the web worker to implement the countdown component.
- Introduce a mechanism to prevent users from changing their local clock. If the difference between the current and previous remaining time is more than 2 seconds, the server offset will be refreshed and the countdown will be recalculated.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Preview URL: https://jac-qualifying-tests-develop--feature-30-ensure-timer-y6eb22ad.web.app/lTikYARL14GGDz6Lh5EI

1. Sit and submit the QT with the following email addresses:
    - user1@test.com
    - user2@test.com
    - user3@test.com
    - user4@test.com
    - user5@test.com

2. Check if the timer works properly under the following user cases:
    - Switch to another window
    - Use the same window and switch to another tab
    - Change the local clock

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
