### PR TITLE
Feature/59 Replace all references to 'Dry Run' on the QT Platform with 'Mock Assessment'

### DIFF
--- a/qt-admin/src/filters.js
+++ b/qt-admin/src/filters.js
@@ -60,6 +60,7 @@ const lookup = (value) => {
     'online-and-judge-led': 'Yes - online resources and judge-led discussion group course',
     'online-only': 'Yes - online resources only',
 
+    'dry-run': 'Mock assessment',
     // 'xxx': 'xxx',
   };
 

--- a/qt-admin/src/router.js
+++ b/qt-admin/src/router.js
@@ -114,7 +114,7 @@ const routes = [
             name: 'qualifying-test-dry-run',
             meta: {
               requiresAuth: true,
-              title: 'Dry Run | Qualifying Test',
+              title: 'Mock Assessment | Qualifying Test',
             },
           },
           {

--- a/qt-admin/src/views/QualifyingTests/New.vue
+++ b/qt-admin/src/views/QualifyingTests/New.vue
@@ -82,7 +82,7 @@ export default {
 
     return {
       qualifyingTest: qualifyingTest,
-      isDryRun: true, // all tests created on QT Platform are considered dry runs. Main tests are created via API integration
+      isDryRun: true, // all tests created on QT Platform are considered mock assessments. Main tests are created via API integration
     };
   },
   computed: {

--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/DryRun.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/DryRun.vue
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form @submit.prevent="validateAndSave">
         <h2 class="govuk-heading-l">
-          Edit {{ isTieBreaker ? 'equal merit tie-breaker' : 'qualifying test' }} dry run details
+          Edit {{ isTieBreaker ? 'equal merit tie-breaker' : 'qualifying test' }} mock assessment details
         </h2>
 
         <ErrorSummary

--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/Review.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/Review.vue
@@ -206,12 +206,12 @@
           class="govuk-link"
           :to="{name: `${routeNamePrefix}-dry-run`}"
         >
-          Update dry run details
+          Update mock assessment details
         </router-link>
       </div>
 
       <h2 class="govuk-heading-m">
-        Dry run details
+        Mock assessment details
       </h2>
 
       <dl class="govuk-summary-list">

--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/View.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/View.vue
@@ -57,7 +57,7 @@
               </a>
             </td>
           </tr>
-          <tr 
+          <tr
             v-if="authorisedToPerformAction"
             class="govuk-table__row"
           >
@@ -174,7 +174,7 @@
             class="govuk-!-margin-right-3"
             :action="btnInitialise"
           >
-            Create dry run tests
+            Create mock assessment tests
           </ActionButton>
           <router-link
             v-if="!isDryRunCandidates"


### PR DESCRIPTION
## What's included?
Closes #59.

- Replace DRY RUN tag with MOCK ASSESSMENT tag.
- Replace any occurrences of 'Dry run' in text content with 'Mock Assessment'.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Preview URL: https://jac-qualifying-tests-admin-develop--replace-dry-run-zgeuhj7o.web.app/folder/JMl1UBiubU2TxX6T3Lbf/qualifying-tests

1. Check if "DRY RUN" tags have been changed to "MOCK ASSESSMENT" in the QT list.
2. Go to a QT edit page and check if all "Dry run" texts have been changed to "Mock assessment".

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/qt/assets/79906532/a7e9f317-3260-4102-9b39-713a9c7aed2a
