### PR TITLE
Fix/67 remove mysterious blue box

### DIFF
--- a/qt/src/views/QualifyingTests/QualifyingTest/Submitted.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Submitted.vue
@@ -65,14 +65,12 @@
       <Banner
         status="information"
       >
-        <template>
-          <a
-            :href="qualifyingTestResponse.qualifyingTest.feedbackSurvey"
-            class="govuk-link info-link--submitted--banner--click-here-to-fill-out-our-feedback-survey"
-          >
-            Click here to fill out our feedback survey
-          </a>
-        </template>
+        <a
+          :href="qualifyingTestResponse.qualifyingTest.feedbackSurvey"
+          class="govuk-link info-link--submitted--banner--click-here-to-fill-out-our-feedback-survey"
+        >
+          Click here to fill out our feedback survey
+        </a>
       </Banner>
     </div>
   </div>


### PR DESCRIPTION
## What's included?
Closes #67 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to this QT preview link: https://jac-qualifying-tests-develop--67-qt-remove-remove-myst-wo0qxr60.web.app/yQd5CHbYklYVydWX6BrX
- Sign-in with one of emails
```
tester1@jac-dummy-email.uk
tester2@jac-dummy-email.uk
tester3@jac-dummy-email.uk
tester4@jac-dummy-email.uk
tester5@jac-dummy-email.uk
tester6@jac-dummy-email.uk
tester7@jac-dummy-email.uk
tester8@jac-dummy-email.uk
tester9@jac-dummy-email.uk
```
- Complete the QT and submit
- The submitted page should display the survey link in the blue box
<img width="1505" alt="Screenshot 2024-03-08 at 17 39 30" src="https://github.com/jac-uk/qt/assets/156695133/6686e4d2-fd7e-47d5-b66b-f87dd9d90d18">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, video demo, notes etc.

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
