### PR TITLE
Ticketing System #355 - Remove the skip and previous buttons from the top nav

### DIFF
--- a/qt/src/views/QualifyingTests/QualifyingTest.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest.vue
@@ -18,7 +18,7 @@
         :alert="1"
         @change="handleCountdown"
       >
-        <template
+        <!-- <template
           #left-slot
         >
           <span>
@@ -46,7 +46,8 @@
           >
             ❯
           </a>
-        </template>
+        </template> -->
+
         <!--
           <template
           #right-slot


### PR DESCRIPTION
 Remove the skip and previous buttons from the top nav to fix the issue reported in Ticketing Issue 355;

Closes jac-uk/ticketing-system#355