### PR TITLE
Ticketing System #355 Only Remove Skip And Previous Buttons For Scenario Tests

### DIFF
--- a/qt/src/helpers/exerciseHelper.js
+++ b/qt/src/helpers/exerciseHelper.js
@@ -1,5 +1,6 @@
 /*eslint func-style: ["error", "declaration"]*/
 import clone from 'clone';
+import { QUALIFYING_TEST } from '@/helpers/constants';
 
 /** Used in Admin:-
 APPLICATION_STEPS,
@@ -56,7 +57,10 @@ export {
   isMoreInformationNeeded,
   isApplicationComplete,
   hasApplicationProcess,
-  informationDeadline
+  informationDeadline,
+  isScenarioTest,
+  isCriticalAnalysisTest,
+  isSituationalJudgementTest
 };
 
 // const EXERCISE_STATES = ['draft', 'ready', 'approved', 'shortlisting', 'selection', 'recommendation', 'handover', 'archived'];
@@ -475,4 +479,16 @@ function informationDeadline(exercise) {
     }
   }
   return null;
+}
+
+function isScenarioTest(qualifyingTest) {
+  return qualifyingTest.type === QUALIFYING_TEST.TYPE.SCENARIO;
+}
+
+function isCriticalAnalysisTest(qualifyingTest) {
+  return qualifyingTest.type === QUALIFYING_TEST.TYPE.CRITICAL_ANALYSIS;
+}
+
+function isSituationalJudgementTest(qualifyingTest) {
+  return qualifyingTest.type === QUALIFYING_TEST.TYPE.SITUATIONAL_JUDGEMENT;
 }

--- a/qt/src/helpers/object.js
+++ b/qt/src/helpers/object.js
@@ -1,0 +1,18 @@
+const objectHasNestedProperty = (obj, dotPath) => {
+  if (typeof dotPath !== 'string' || dotPath.trim() === '') {
+    return false;
+  }
+  const keys = dotPath.split('.');
+  let currentObj = obj;
+  for (const key of keys) {
+    if (!currentObj || typeof currentObj !== 'object' || !Object.prototype.hasOwnProperty.call(currentObj, key)) {
+      return false;
+    }
+    currentObj = currentObj[key];
+  }
+  return true;
+};
+
+export {
+  objectHasNestedProperty
+};

--- a/qt/src/views/QualifyingTests/QualifyingTest.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest.vue
@@ -18,7 +18,8 @@
         :alert="1"
         @change="handleCountdown"
       >
-        <!-- <template
+        <template
+          v-if="!isScenarioTest"
           #left-slot
         >
           <span>
@@ -35,6 +36,7 @@
         </template>
 
         <template
+          v-if="!isScenarioTest"
           #right-slot
         >
           <a
@@ -46,7 +48,7 @@
           >
             ❯
           </a>
-        </template> -->
+        </template>
 
         <!--
           <template
@@ -102,6 +104,9 @@ import LoadingMessage from '@/components/LoadingMessage.vue';
 import Modal from '@/components/Page/Modal.vue';
 import Countdown from '@/components/QualifyingTest/Countdown.vue';
 import Banner from '@/components/Page/Banner.vue';
+import { isScenarioTest } from '@/helpers/exerciseHelper.js';
+import { objectHasNestedProperty } from '@/helpers/object.js';
+
 export default {
   components: {
     LoadingMessage,
@@ -144,6 +149,13 @@ export default {
     },
     isCompleted() {
       return this.$store.getters['qualifyingTestResponse/isCompleted'];
+    },
+    isScenarioTest() {
+      if (objectHasNestedProperty(this.qualifyingTestResponse, 'qualifyingTest.type')) {
+        return isScenarioTest(this.qualifyingTestResponse.qualifyingTest);
+      }
+      console.log('qualifyingTestResponse is missing qualifyingTest.type');
+      return false;
     },
   },
   watch: {


### PR DESCRIPTION
A previous hotfix PR removed the skip and previous buttons but did it for all test types.
See: https://github.com/jac-uk/qt/pull/78

It should only have been for scenario tests. This PR fixes that.

Closes jac-uk/ticketing-system#355