### PR TITLE
Hotfix/revert jac kit upgrade

### DIFF
--- a/qt-admin/package-lock.json
+++ b/qt-admin/package-lock.json
@@ -8,7 +8,7 @@
       "name": "qt-admin",
       "version": "1.2.0",
       "dependencies": {
-        "@jac-uk/jac-kit": "4.1.24",
+        "@jac-uk/jac-kit": "3.0.41",
         "@ministryofjustice/frontend": "0.2.4",
         "@rollup/plugin-inject": "^5.0.4",
         "@sentry/vue": "^7.73.0",
@@ -1452,16 +1452,14 @@
       "dev": true
     },
     "node_modules/@jac-uk/jac-kit": {
-      "version": "4.1.24",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.24/80f0639d7b1e5832f3d65d52f198f70952309c5e",
-      "integrity": "sha512-FOe8pAEzlbNn0+WxI2sithwCoVDqHISr2NOxSaITImE1p9y2FEvtFdI9XK5hirTnN0f6BtnBCWcYP2E8UBw4QA==",
+      "version": "3.0.41",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.41/665f5eae3e2e255a38b009c9714081351cf38bd0",
+      "integrity": "sha512-k0Ao2nEOh/j3c7gGnSSRh2v2QIqtQlbEDytYoajpU66EIRcDz+uwS94tGUunrXy79q84crAB0csPCmchUJRHhw==",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",
         "save-file": "^2.3.1",
         "stream-browserify": "^3.0.0",
-        "uid": "^2.0.2",
-        "vue-dompurify-html": "^5.1.0",
         "xlsx-populate": "^1.21.0"
       }
     },
@@ -1635,14 +1633,6 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "optional": true,
       "peer": true
-    },
-    "node_modules/@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@ministryofjustice/frontend": {
       "version": "0.2.4",
@@ -3191,11 +3181,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/dompurify": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
-      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "node_modules/dtype": {
       "version": "2.0.0",
@@ -6873,17 +6858,6 @@
       "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
       "dev": true
     },
-    "node_modules/uid": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
-      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
-      "dependencies": {
-        "@lukeed/csprng": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -7186,17 +7160,6 @@
         "@vue/runtime-dom": "3.3.4",
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/vue-dompurify-html": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vue-dompurify-html/-/vue-dompurify-html-5.1.0.tgz",
-      "integrity": "sha512-616o2/PBdOLM2bwlRWLdzeEC9NerLkwiudqNgaIJ5vBQWXec+u7Kuzh+45DtQQrids67s4pHnTnJZLVfyPMxbA==",
-      "dependencies": {
-        "dompurify": "^3.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -8530,16 +8493,14 @@
       "dev": true
     },
     "@jac-uk/jac-kit": {
-      "version": "4.1.24",
-      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/4.1.24/80f0639d7b1e5832f3d65d52f198f70952309c5e",
-      "integrity": "sha512-FOe8pAEzlbNn0+WxI2sithwCoVDqHISr2NOxSaITImE1p9y2FEvtFdI9XK5hirTnN0f6BtnBCWcYP2E8UBw4QA==",
+      "version": "3.0.41",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/3.0.41/665f5eae3e2e255a38b009c9714081351cf38bd0",
+      "integrity": "sha512-k0Ao2nEOh/j3c7gGnSSRh2v2QIqtQlbEDytYoajpU66EIRcDz+uwS94tGUunrXy79q84crAB0csPCmchUJRHhw==",
       "requires": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",
         "save-file": "^2.3.1",
         "stream-browserify": "^3.0.0",
-        "uid": "^2.0.2",
-        "vue-dompurify-html": "^5.1.0",
         "xlsx-populate": "^1.21.0"
       },
       "dependencies": {
@@ -8680,11 +8641,6 @@
           "peer": true
         }
       }
-    },
-    "@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="
     },
     "@ministryofjustice/frontend": {
       "version": "0.2.4",
@@ -9840,11 +9796,6 @@
           "dev": true
         }
       }
-    },
-    "dompurify": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
-      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "dtype": {
       "version": "2.0.0",
@@ -12613,14 +12564,6 @@
       "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
       "dev": true
     },
-    "uid": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
-      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
-      "requires": {
-        "@lukeed/csprng": "^1.0.0"
-      }
-    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -12785,14 +12728,6 @@
         "@vue/runtime-dom": "3.3.4",
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
-      }
-    },
-    "vue-dompurify-html": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/vue-dompurify-html/-/vue-dompurify-html-5.1.0.tgz",
-      "integrity": "sha512-616o2/PBdOLM2bwlRWLdzeEC9NerLkwiudqNgaIJ5vBQWXec+u7Kuzh+45DtQQrids67s4pHnTnJZLVfyPMxbA==",
-      "requires": {
-        "dompurify": "^3.0.0"
       }
     },
     "vue-eslint-parser": {

--- a/qt-admin/package.json
+++ b/qt-admin/package.json
@@ -18,7 +18,7 @@
     "lint-ci": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --no-fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "4.1.24",
+    "@jac-uk/jac-kit": "3.0.41",
     "@ministryofjustice/frontend": "0.2.4",
     "@rollup/plugin-inject": "^5.0.4",
     "@sentry/vue": "^7.73.0",


### PR DESCRIPTION
Rollback the upgrade to latest version of jac-kit as it uses the latest firebase which isnt working yet with our current qt-admin