### PR TITLE
fix participant numbers when resetting or moving to mop up

### DIFF
--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -70,6 +70,14 @@ module.exports = (config, firebase, db) => {
         statusAfter === config.QUALIFYING_TEST_RESPONSES.STATUS.ACTIVATED
       ) {
         data[`counts.${config.QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED}`] = decrement;
+        // rollback started number if added
+        if (dataBefore.statusLog &&
+            dataAfter.statusLog &&
+            dataBefore.statusLog[config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED] !== null &&
+            dataAfter.statusLog[config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED] === null) {
+          
+            data[`counts.${config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED}`] = decrement; 
+        }
         // reset auto submit counts and flag
         if (dataAfter.isOutOfTime) {
           data['counts.outOfTime'] = decrement;
@@ -79,6 +87,14 @@ module.exports = (config, firebase, db) => {
             }, {merge: true});
           }
         }
+      }
+
+      // mark activated to completed
+      if (
+        statusBefore === config.QUALIFYING_TEST_RESPONSES.STATUS.ACTIVATED &&
+        statusAfter === config.QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED
+      ) {
+        data[`counts.${statusAfter}`] = increment;
       }
 
       if (Object.keys(data).length > 0) {

--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -150,6 +150,9 @@ module.exports = (config, firebase, db) => {
       previousStatuses.push(status);
       if (status === targetStatus) break;
     }
+    if (targetStatus === config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED) {
+      previousStatuses.push('inProgress');
+    }
     return previousStatuses;
   }
 

--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -103,11 +103,16 @@ module.exports = (config, firebase, db) => {
       const decrement = firebase.firestore.FieldValue.increment(-1);
 
       // reset counts of previous statuses
-      const previousStatuses = listPreviousStatuses(dataAfter.status);
+      const previousStatuses = listPreviousStatuses(dataBefore.status);
+
       const updateBefore = previousStatuses.reduce((data, status) => {
         data[`counts.${status}`] = decrement;
         return data;
       }, {});
+      if (dataBefore.isOutOfTime) {
+        updateBefore['counts.outOfTime'] = decrement;
+      }
+
       const updateAfter = {
         'counts.initialised': increment,
       };
@@ -131,9 +136,9 @@ module.exports = (config, firebase, db) => {
   function listPreviousStatuses(targetStatus) {
     const orderedStatuses = [
       'initialised',
-      QUALIFYING_TEST_RESPONSES.STATUS.STARTED,
-      'inProgress',
-      QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED,
+      config.QUALIFYING_TEST_RESPONSES.STATUS.ACTIVATED,
+      config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED,
+      config.QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED,
     ];
 
     if (!orderedStatuses.includes(targetStatus)) {

--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -11,7 +11,7 @@ module.exports = (config, firebase, db) => {
    * - if status has changed to started or completed update counts in qualifyingTest
    * - if document has been moved to another qualifyingTest then update counts in both tests
    */
-  async function onUpdate(dataBefore, dataAfter) {
+  async function onUpdate(dataBefore, dataAfter, ref) {
     if (dataBefore.status !== dataAfter.status) {
       const increment = firebase.firestore.FieldValue.increment(1);
       const decrement = firebase.firestore.FieldValue.increment(-1);
@@ -27,6 +27,16 @@ module.exports = (config, firebase, db) => {
         data[`counts.${statusAfter}`] = increment;
         data['counts.inProgress'] = increment;
       }
+
+      // reset started test
+      if (
+        statusBefore === config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED &&
+        statusAfter === config.QUALIFYING_TEST_RESPONSES.STATUS.ACTIVATED
+      ) {
+        data[`counts.${config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED}`] = decrement;
+        data['counts.inProgress'] = decrement;
+      }
+
       // completed test
       if (
         statusBefore === config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED &&
@@ -53,16 +63,40 @@ module.exports = (config, firebase, db) => {
         };
         sendEmail(participantEmail, templateId, personalisation);
       }
+
+      // reset completed test
+      if (
+        statusBefore === config.QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED &&
+        statusAfter === config.QUALIFYING_TEST_RESPONSES.STATUS.ACTIVATED
+      ) {
+        data[`counts.${config.QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED}`] = decrement;
+        // reset auto submit counts and flag
+        if (dataAfter.isOutOfTime) {
+          data['counts.outOfTime'] = decrement;
+          if (ref) {
+            await ref.set({
+              isOutOfTime: false,
+            }, {merge: true});
+          }
+        }
+      }
+
       if (Object.keys(data).length > 0) {
         await db.doc(`qualifyingTests/${qualifyingTestId}`).update(data);
       }
     }
+
+    // move participant to other test (mop up test)
     if (dataBefore.qualifyingTest.id !== dataAfter.qualifyingTest.id) {
       const increment = firebase.firestore.FieldValue.increment(1);
       const decrement = firebase.firestore.FieldValue.increment(-1);
-      const updateBefore = {
-        'counts.initialised': decrement,
-      };
+
+      // reset counts of previous statuses
+      const previousStatuses = listPreviousStatuses(dataAfter.status);
+      const updateBefore = previousStatuses.reduce((data, status) => {
+        data[`counts.${status}`] = decrement;
+        return data;
+      }, {});
       const updateAfter = {
         'counts.initialised': increment,
       };
@@ -81,6 +115,26 @@ module.exports = (config, firebase, db) => {
       return result;
     }
     return true;
+  }
+
+  function listPreviousStatuses(targetStatus) {
+    const orderedStatuses = [
+      'initialised',
+      QUALIFYING_TEST_RESPONSES.STATUS.STARTED,
+      'inProgress',
+      QUALIFYING_TEST_RESPONSES.STATUS.COMPLETED,
+    ];
+
+    if (!orderedStatuses.includes(targetStatus)) {
+      return [];
+    }
+
+    const previousStatuses = [];
+    for (const status of orderedStatuses) {
+      previousStatuses.push(status);
+      if (status === targetStatus) break;
+    }
+    return previousStatuses;
   }
 
 };

--- a/platform/functions/actions/qualifyingTestResponses/onUpdate.js
+++ b/platform/functions/actions/qualifyingTestResponses/onUpdate.js
@@ -79,13 +79,8 @@ module.exports = (config, firebase, db) => {
             data[`counts.${config.QUALIFYING_TEST_RESPONSES.STATUS.STARTED}`] = decrement; 
         }
         // reset auto submit counts and flag
-        if (dataAfter.isOutOfTime) {
+        if (dataBefore.isOutOfTime && !dataAfter.isOutOfTime) {
           data['counts.outOfTime'] = decrement;
-          if (ref) {
-            await ref.set({
-              isOutOfTime: false,
-            }, {merge: true});
-          }
         }
       }
 

--- a/platform/functions/backgroundFunctions/onQualifyingTestResponseUpdate.js
+++ b/platform/functions/backgroundFunctions/onQualifyingTestResponseUpdate.js
@@ -8,5 +8,5 @@ module.exports = functions.region('europe-west2').firestore
   .onUpdate((change, context) => {
     const dataBefore = change.before.data();
     const dataAfter = change.after.data();
-    return onQualifyingTestResponseUpdate(dataBefore, dataAfter);
+    return onQualifyingTestResponseUpdate(dataBefore, dataAfter, data.after.ref);
   });

--- a/platform/functions/backgroundFunctions/onQualifyingTestResponseUpdate.js
+++ b/platform/functions/backgroundFunctions/onQualifyingTestResponseUpdate.js
@@ -8,5 +8,5 @@ module.exports = functions.region('europe-west2').firestore
   .onUpdate((change, context) => {
     const dataBefore = change.before.data();
     const dataAfter = change.after.data();
-    return onQualifyingTestResponseUpdate(dataBefore, dataAfter, data.after.ref);
+    return onQualifyingTestResponseUpdate(dataBefore, dataAfter, change.after.ref);
   });

--- a/qt-admin/src/store/qualifyingTest/qualifyingTestResponses.js
+++ b/qt-admin/src/store/qualifyingTest/qualifyingTestResponses.js
@@ -134,7 +134,7 @@ export default {
         const data = {
           'status': 'activated',
           'statusLog.reset': timestamp,
-          [`statusLog.${rec.status}`]: null,
+          'statusLog.started': null,
         };
         if (rec.isOutOfTime === true) {
           data.isOutOfTime = false;

--- a/qt-admin/src/store/qualifyingTest/qualifyingTestResponses.js
+++ b/qt-admin/src/store/qualifyingTest/qualifyingTestResponses.js
@@ -134,6 +134,7 @@ export default {
         const data = {
           'status': 'activated',
           'statusLog.reset': timestamp,
+          [`statusLog.${rec.status}`]: null,
         };
         if (rec.isOutOfTime === true) {
           data.isOutOfTime = false;


### PR DESCRIPTION
Closes #89 

How to test:
- Go to the preview link: https://jac-qualifying-tests-admin-develop--qt-89-n85egzzf.web.app/folder/1WkTLw87DWPwT1v6161q/qualifying-tests/4ihcPwRH9KaOrhTMRPu9/
- Use the email to login QT, and test following scenario.
- Reset `started test`, the participant numbers should be correct.

https://github.com/user-attachments/assets/9eda520d-f4d6-4fae-8b50-bd4ec6b979a4


- Reset `competed test`, the participant numbers should be correct.

https://github.com/user-attachments/assets/e40a21f5-3ed7-4128-9d9d-ee854775c59c


- Reset `auto submitted test`, the participant numbers should be correct.

https://github.com/user-attachments/assets/1b7a2322-7c80-4780-87a0-774679233e81


- Reset `mark completed` test, the participant numbers should be correct.

https://github.com/user-attachments/assets/3a98ada7-09f8-45b3-a239-8dd06a52e843


- Move `completed` test to mop up, the participant numbers should be correct.

https://github.com/user-attachments/assets/2c8fe9bb-8e08-4b31-a120-16e266f137a5


- Move `auto submitted` test to mop up, the participant numbers should be correct.

https://github.com/user-attachments/assets/70b02613-0c6f-4d71-b7aa-280fd55af4a1


- Move `started` test to mop up, the participant numbers should be correct.

https://github.com/user-attachments/assets/04b74cb3-8ad1-4993-bb28-fd04f39491ab


