### PR TITLE
Fix Back button

### DIFF
--- a/qt-admin/src/views/QualifyingTests/QualifyingTest.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="xgovuk-grid-row">
-    <RouterLink
+    <a
       class="govuk-back-link"
-      :to="{ name: 'qualifying-tests', params: { folderId: folderId } }"
+      @click="$router.back()"
     >
       Back
-    </RouterLink>
+    </a>
     <span class="govuk-caption-l">{{ folder.name }}</span>
 
     <LoadingMessage

--- a/qt/src/components/BackLink.vue
+++ b/qt/src/components/BackLink.vue
@@ -8,7 +8,7 @@
 </template>
 
 <style scoped>
- .govuk-back-link {
-   cursor: pointer;
- }
+  .govuk-back-link {
+    cursor: pointer;
+  }
 </style>


### PR DESCRIPTION
Back button now uses the router history to navigate to previous page, as opposed to static target.

relies on #85 merge
closes #92