### PR TITLE
Bugfix/QT response page is blank

### DIFF
--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/Response/View.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/Response/View.vue
@@ -280,7 +280,7 @@
                 <br>
                 <QuestionDuration
                   v-if="!isScenario"
-                  :start="questionStartTimestamps(index).length ? questionStartTimestamps(index) : responses[index].started"
+                  :start="questionStartTimestamps(index).length ? questionStartTimestamps(index) : responses[index]?.started"
                   :end="lastUpdatedQuestion(index)"
                 />
                 <div


### PR DESCRIPTION
### What's included?

**Problem:**

The QT response page is blank if the QT hasn't been completed. 

<img width="1257" alt="Screenshot 2024-11-29 at 09 33 27" src="https://github.com/user-attachments/assets/b2c6a43d-baed-4787-bafd-67a98ad62c28">
