### PR TITLE
#115 Bugfix: Mop-up. Question lockout banner and logic

### DIFF
--- a/.github/workflows/qt-on-merge.yml
+++ b/.github/workflows/qt-on-merge.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -78,7 +78,7 @@ jobs:
 
       # Cache node modules
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ platform/data/auth_export/accounts.json
 
 # ds store
 .DS_Store
+
+platform/data/storage_export

--- a/platform/.gitignore
+++ b/platform/.gitignore
@@ -112,3 +112,5 @@ out/
 /data/firestore.json
 /data/firestore_export/
 /data/firebase-export-metadata.json
+/data/storage_export/
+/data/storage_export/buckets.json

--- a/qt/src/components/Form/RadioItem.vue
+++ b/qt/src/components/Form/RadioItem.vue
@@ -10,6 +10,7 @@
         :name="inputName[field]"
         :value="value"
         :aria-describedby="hint ? hintId : false"
+        :disabled="disabled"
       >
       <input
         v-else
@@ -20,6 +21,7 @@
         :name="inputName"
         :value="value"
         :aria-describedby="hint ? hintId : null"
+        :disabled="disabled"
       >
       <label
         class="govuk-label govuk-radios__label"
@@ -67,6 +69,11 @@ export default {
     hint: {
       default: '',
       type: String,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   data() {

--- a/qt/src/views/QualifyingTests/QualifyingTest/Question.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Question.vue
@@ -270,7 +270,6 @@ export default {
       if (!this.previousTestQuestion) {
         const saveData = saveHistoryAndSession({ action: 'changed', txt: 'Changed', answer: { value: val.value, type: val.type } }, this.questionNumber, this.questionSessionStart);
         await this.$store.dispatch('qualifyingTestResponse/save', saveData);
-        // this.save(false, { action: 'changed', answer: { value: val.value, type: val.type } });
       }
     },
     questionStartedOnPreviousTest() {

--- a/qt/src/views/QualifyingTests/QualifyingTest/Question.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Question.vue
@@ -1,25 +1,25 @@
 <template>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <Banner
-        v-if="previousTestQuestion"
-        status="warning"
-      >
-        <template>
-          You cannot amend your answer for this question as it was started on a previous test
-        </template>
-      </Banner>
-
       <form
-        v-if="response"
+        v-if="response && loaded"
         ref="formRef"
         @submit.prevent="save(true, {})"
       >
+
+        <Banner
+          v-if="previousTestQuestion"
+          status="warning"
+        >
+          You cannot amend your answer for this question as it was started on a previous test
+        </Banner>
+
         <component
           :is="questionType"
           v-model="response.selection"
           :question="`${questionNumber}. ${question.details}`"
           :options="question.options"
+          :disabled="previousTestQuestion"
           @answered="questionAnswered"
         />
 
@@ -29,6 +29,7 @@
         >
           Please select one option 'Most appropriate' and one 'Least appropriate' before clicking on 'Save and continue'.
         </p>
+
         <div class="moj-button-menu">
           <div class="moj-button-menu__wrapper">
             <button
@@ -39,6 +40,7 @@
               {{ isComingFromReview || isLastQuestion ? 'Skip to Review' : 'Skip to next question' }}
             </button>
             <ActionButton
+              v-if="!previousTestQuestion"
               :propclass="`moj-button-menu__item govuk-button info-btn--question-${questionNumber}-${$route.params.qualifyingTestId}-save-and-continue`"
               :disabled="!canSaveAndContinue"
               :action="save"
@@ -48,6 +50,7 @@
           </div>
         </div>
       </form>
+      <LoadingMessage v-else/>
     </div>
   </div>
 </template>
@@ -59,6 +62,7 @@ import { QUALIFYING_TEST } from '@/helpers/constants';
 import Banner from '@/components/Page/Banner.vue';
 import { prepareSaveHistory, prepareSaveQuestionSession, saveHistoryAndSession } from '@/helpers/qualifyingTestResponseHelpers';
 import ActionButton from '@/components/ActionButton.vue';
+import LoadingMessage from '@/components/LoadingMessage.vue';
 
 export default {
   components: {
@@ -66,6 +70,7 @@ export default {
     SituationalJudgement,
     Banner,
     ActionButton,
+    LoadingMessage,
   },
   beforeRouteEnter(to, from, next) {
     next((vm) => {
@@ -115,6 +120,7 @@ export default {
       previousTestQuestion: false,
       questionSessionStart: Timestamp.now(),
       isComingFromReview: false,
+      loaded: false,
     };
   },
   computed: {
@@ -188,7 +194,7 @@ export default {
             location: 'modal',
             question: this.questionNumber - 1,
           };
-          const saveData = await saveHistoryAndSession(sessionData, this.questionNumber, this.questionSessionStart);
+          const saveData = saveHistoryAndSession(sessionData, this.questionNumber, this.questionSessionStart);
           await this.$store.dispatch('qualifyingTestResponse/save', saveData);
         }
       }
@@ -211,11 +217,12 @@ export default {
       if (this.qualifyingTestResponse._unlockPreviousAnswers !== true) {
         this.questionStartedOnPreviousTest();
       }
+      this.loaded = true;
     }
   },
   methods: {
     async skip() {
-      const saveData = await saveHistoryAndSession({ action: 'skip', txt: 'Skip' }, this.questionNumber, this.questionSessionStart);
+      const saveData = saveHistoryAndSession({ action: 'skip', txt: 'Skip' }, this.questionNumber, this.questionSessionStart);
       await this.$store.dispatch('qualifyingTestResponse/save', saveData);
       this.$router.push(this.nextPage);
     },
@@ -255,16 +262,23 @@ export default {
         });
         return;
       } else {
-        const saveData = await saveHistoryAndSession({ action: 'start' }, this.questionNumber, this.questionSessionStart);
+        const saveData = saveHistoryAndSession({ action: 'start' }, this.questionNumber, this.questionSessionStart);
         await this.$store.dispatch('qualifyingTestResponse/save', saveData);
       }
     },
-    questionAnswered(val) {
-      this.save(false, { action: 'changed', answer: { value: val.value, type: val.type } });
+    async questionAnswered(val) {
+      if (!this.previousTestQuestion) {
+        const saveData = saveHistoryAndSession({ action: 'changed', txt: 'Changed', answer: { value: val.value, type: val.type } }, this.questionNumber, this.questionSessionStart);
+        await this.$store.dispatch('qualifyingTestResponse/save', saveData);
+        // this.save(false, { action: 'changed', answer: { value: val.value, type: val.type } });
+      }
     },
     questionStartedOnPreviousTest() {
       if (this.response.started && this.response.completed) {
-        if (this.response.started < this.qualifyingTestResponse.qualifyingTest.startDate) {
+        if (
+          this.response.started < this.qualifyingTestResponse.qualifyingTest.startDate
+          && this.response.completed < this.qualifyingTestResponse.qualifyingTest.startDate
+        ) {
           this.previousTestQuestion = true;
         }
       }

--- a/qt/src/views/QualifyingTests/QualifyingTest/Question/CriticalAnalysis.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Question/CriticalAnalysis.vue
@@ -11,6 +11,7 @@
         :key="index"
         :value="index"
         :label="item.answer"
+        :disabled="disabled"
       />
     </RadioGroup>
   </fieldset>
@@ -36,6 +37,11 @@ export default {
     options: {
       type: Array,
       required: true,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   emits: ['update:modelValue', 'answered'],

--- a/qt/src/views/QualifyingTests/QualifyingTest/Question/SituationalJudgement.vue
+++ b/qt/src/views/QualifyingTests/QualifyingTest/Question/SituationalJudgement.vue
@@ -16,12 +16,14 @@
         <p>
           <RadioItem
             :value="index"
+            :disabled="disabled"
             field="mostAppropriate"
             label="Most appropriate"
           />
           <br>
           <RadioItem
             :value="index"
+            :disabled="disabled"
             field="leastAppropriate"
             label="Least appropriate"
           />
@@ -51,6 +53,11 @@ export default {
     options: {
       type: Array,
       required: true,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   emits: ['update:modelValue', 'answered'],


### PR DESCRIPTION
Closes #115

---

Adds support for the following logic:

- Questions answered in a previous test should be read-only
- Questions unanswered in a previous test should be editable

ie. 

If a user has already answered a question in a previous test then they should not be able to change their answer.

If a user has not answered a question in a previous test then they should be allowed to provide an answer.

If a user has not answered a question in a previous test and provided an answer in this test they should be able to change their answer.

---

**Fixes**
- [x] Not able to amend answers to unanswered questions from previous test
- [x] Able to amend answers provided in a previous test
- [x] Warning banner is not displaying correctly (see below)

<img width="819" alt="Image" src="https://github.com/user-attachments/assets/c58b7eaf-fdd5-479b-bd35-754bf9271dd4" />