### PR TITLE
#123 Tweaks following QT Testing

### DIFF
--- a/qt-admin/src/App.vue
+++ b/qt-admin/src/App.vue
@@ -42,24 +42,7 @@
         </div>
       </div>
 
-      <div class="govuk-phase-banner govuk-!-margin-bottom-4 print-none">
-        <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">
-            beta
-          </strong>
-          <span class="govuk-phase-banner__text">
-            This is a new service – your
-            <a
-              class="govuk-link govuk-link--no-visited-state"
-              target="_blank"
-              href="https://docs.google.com/forms/d/e/1FAIpQLSexm0qgMV0tOQTFP4QUSegOOX89VeYhWwuofV---JZTOEXGIQ/viewform"
-            >
-              feedback
-            </a>
-            will help us to improve it.
-          </span>
-        </p>
-      </div>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-4">
     </header>
 
     <main

--- a/qt-admin/src/views/QualifyingTests/QualifyingTest/View.vue
+++ b/qt-admin/src/views/QualifyingTests/QualifyingTest/View.vue
@@ -193,6 +193,9 @@
             class="display-block govuk-heading-l govuk-!-margin-top-1"
           >{{ qualifyingTest.counts.completed }} / {{ qualifyingTest.counts.outOfTime }}</span>
         </p>
+
+        <p v-if="isCompleted" class="govuk-body-s govuk-!-margin-bottom-0 note">@judicialappointments.digital email addresses are excluded from final counts</p>
+
       </div>
     </div>
 
@@ -730,7 +733,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .tooltip-anchor {
   position: relative;
   width: 20px;
@@ -755,5 +758,9 @@ export default {
 .tooltip-wrapper {
   position: absolute;
   top: -10px
+}
+
+.note {
+  color: $govuk-secondary-text-colour;
 }
 </style>


### PR DESCRIPTION
Closes #123

---

## Background
Following extensive testing after the QT postponement last week, there are a few tweaks to make.


## Feature(s) Description
 - [x] Remove beta tag and text from header
 - [x] Add messaging about .digital email addresses to avoid confusion

---
Amended header:
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/8cf969de-7693-404a-a0ac-d2c61d78e7a6" />


Messaging about .digital email addresses:
<img width="590" alt="image" src="https://github.com/user-attachments/assets/1738f1c1-562e-4683-9b3a-4c5ceba6d923" />

